### PR TITLE
Proposition: Change configuration source from env vars to toml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-.env
-.envrc
 node_modules
 config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .envrc
 node_modules
+config.toml

--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 Use `yanky` to get the GitHub pull requests of a specific team in your organization.
 
-## Environment
+## Setup
+1. Create config.toml (see "Configuration file)
+2. Update your shell (see "Changes to shell environment")
+3. `npm install`
+4. You should be good to call `yanky` from anywhere now.
 
-We recommend managing the environment with a `.envrc` file and using `direnv`. You can copy `envrc.example` to `.envrc` to start.
+## Configuration file
 
-### Required environment variables are:
-- OWNER: GitHub organization name
-- TOKEN: Your personal access token (see below)
-- TEAM_SLUG: GitHub team name (will be snake-case with no accents, so "Les Très Émus 4" would be `les-tres-emus-4`)
+Copy `config.toml.example` to `config.toml` and supply the following parameters:
 
-### Optional
+### Required parameters:
+- owner: GitHub organization name
+- token: Your personal access token (see below)
+- team_slug: GitHub team name (will be snake-case with no accents, so "Les Très Émus 4" would be `les-tres-emus-4`)
 
-- EXCLUDE_BOTS: (optional) if "false", results will include Bot-created PR, such as those by dependabot.
+### Optional parameter:
+
+- exclude_bots: (optional) if "false", results will include Bot-created PR, such as those by dependabot.
+
+## Changes to shell environment
+
+You need to make the `yanky` directory available in your environment as `YANKY_PROJECT_PATH`. The `yanky` script is just a wrapper around `npm start` with a `--prefix` argument to tell `npm` where to find the `package.json`, etc. You will also want this directory to your path so you can run `yanky` from anywhere. In `.zshrc` (the default shell in macOS) this would involve:
+
+```
+export YANKY_PATH="${HOME}/<your path>/yanky"
+export PATH="${YANKY_PATH}:${PATH}"
+```
 
 ## GitHub Fine-grained Personal Access Token
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Copy `config.toml.example` to `config.toml` and supply the following parameters:
 
 ## Changes to shell environment
 
-You need to make the `yanky` directory available in your environment as `YANKY_PROJECT_PATH`. The `yanky` script is just a wrapper around `npm start` with a `--prefix` argument to tell `npm` where to find the `package.json`, etc. You will also want this directory to your path so you can run `yanky` from anywhere. In `.zshrc` (the default shell in macOS) this would involve:
+You need to make the `yanky` directory available in your environment as `YANKY_PATH`. The `yanky` script is just a wrapper around `npm start` with a `--prefix` argument to tell `npm` where to find the `package.json`, etc. You will also want this directory to your path so you can run `yanky` from anywhere. In `.zshrc` (the default shell in macOS) this would involve:
 
 ```
 export YANKY_PATH="${HOME}/<your path>/yanky"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Copy `config.toml.example` to `config.toml` and supply the following parameters:
 ### Required parameters:
 - owner: GitHub organization name
 - token: Your personal access token (see below)
-- team_slug: GitHub team name (will be snake-case with no accents, so "Les Très Émus 4" would be `les-tres-emus-4`)
+- team_slug: GitHub team name (will be kebab-case with no accents, so "Les Très Émus 4" would be `les-tres-emus-4`)
 
 ### Optional parameter:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Copy `config.toml.example` to `config.toml` and supply the following parameters:
 
 ## Changes to shell environment
 
-You need to make the `yanky` directory available in your environment as `YANKY_PATH`. The `yanky` script is just a wrapper around `npm start` with a `--prefix` argument to tell `npm` where to find the `package.json`, etc. You will also want this directory to your path so you can run `yanky` from anywhere. In `.zshrc` (the default shell in macOS) this would involve:
+You need to make the `yanky` directory available in your environment as `YANKY_PATH`. The `yanky` script is just a wrapper around `npm start` with a `--prefix` argument to tell `npm` where to find the `package.json`, etc. You'll also want to add this directory to your path so you can run `yanky` from anywhere. In `.zshrc` (the default shell in macOS) this would involve:
 
 ```
 export YANKY_PATH="${HOME}/<your path>/yanky"

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,4 @@
+owner = "rum-and-code"
+token = ""
+team = ""
+exclude_bots = true

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,4 +1,4 @@
 owner = "rum-and-code"
 token = ""
-team = ""
+team_slug = ""
 exclude_bots = true

--- a/envrc.example
+++ b/envrc.example
@@ -1,4 +1,0 @@
-export OWNER=
-export TOKEN=
-export TEAM_SLUG=
-export EXCLUDE_BOTS=true

--- a/index.js
+++ b/index.js
@@ -1,16 +1,22 @@
 const axios = require('axios');
 const { Command } = require('commander');
-const program = new Command();
-const dotenv = require('dotenv');
+const fs = require('fs');
+const toml = require('toml');
 
-dotenv.config();
+const program = new Command();
+
+if (!fs.existsSync('./config.toml')) {
+  console.error('Error: config.toml not found');
+  process.exit(1);
+}
+
+const file = fs.readFileSync('./config.toml', 'utf-8');
+config = toml.parse(file);
+
 program.version('1.0.0');
 program
   .action(async () => {
-    const owner = process.env.OWNER;
-    const team = process.env.TEAM_SLUG;
-    const token = process.env.TOKEN;
-    const excludeBots = (process.env.EXCLUDE_BOTS && process.env.EXCLUDE_BOTS != 'false') || true;
+    const { owner, team, token, exclude_bots: excludeBots } = config;
     const headers = {
       'Authorization': `Bearer ${token}`,
       'Accept': 'application/vnd.github+json',
@@ -22,7 +28,7 @@ program
     console.log('\x1b[33m%s\x1b[0m%s', "Team: ", team);
     console.log("\nFetching repositories...");
 
-    const response = await axios.get(`https://api.github.com/orgs/${owner}/repos?per_page=100`, {headers});
+    const response = await axios.get(`https://api.github.com/orgs/${owner}/repos?per_page=100`, { headers });
     if (response.status !== 200) {
       console.error(`Error: ${response.status} ${response.statusText}`);
       process.exit(1);
@@ -31,7 +37,7 @@ program
     console.log("Found", repoNames.length, "repositories for organization", owner);
 
     const filterByTeam = async (repoName) => {
-      const response = await axios.get(`https://api.github.com/repos/${owner}/${repoName}/teams`, {headers});
+      const response = await axios.get(`https://api.github.com/repos/${owner}/${repoName}/teams`, { headers });
       if (response.status !== 200) {
         console.error(`Error: ${response.status} ${response.statusText}`);
         process.exit(1);
@@ -46,24 +52,25 @@ program
     }
 
     const getOpenPullRequests = async (repoName) => {
-      const response = await axios.get(`https://api.github.com/repos/${owner}/${repoName}/pulls?state=open`, {headers});
+      const response = await axios.get(`https://api.github.com/repos/${owner}/${repoName}/pulls?state=open`, { headers });
       if (response.status !== 200) {
         console.error(`Error: ${response.status} ${response.statusText}`);
         process.exit(1);
       }
       return response.data
-      .filter((pr) => {
-        if (excludeBots) {
-          return pr.user.type !== 'Bot';
-        } else {
-          return true;
-        }
-      })
+        .filter((pr) => {
+          if (excludeBots) {
+            return pr.user.type !== 'Bot';
+          } else {
+            return true;
+          }
+        })
     }
 
-    const enhancePullRequestWithReview = async (pullRequest) => {;
+    const enhancePullRequestWithReview = async (pullRequest) => {
+      ;
       const { number, head: { repo: { name } } } = pullRequest;
-      const response = await axios.get(`https://api.github.com/repos/${owner}/${name}/pulls/${number}/reviews`, {headers});
+      const response = await axios.get(`https://api.github.com/repos/${owner}/${name}/pulls/${number}/reviews`, { headers });
       if (response.status !== 200) {
         console.error(`Error: ${response.status} ${response.statusText}`);
         process.exit(1);
@@ -74,30 +81,30 @@ program
     }
 
     filterAsync(repoNames, filterByTeam)
-    .then(async (repos) => {
-      console.log("Found", repos.length, "repositories for team", team);
-      const result = await Promise.all(repos.map(getOpenPullRequests));
-      const openPullRequests = result.flat();
-      console.log("Found", openPullRequests.length, "open pull requests in these repos");
-      const openPullRequestsWithReviews = await Promise.all(openPullRequests.map(enhancePullRequestWithReview));
-      console.log("Getting reviews for these pull requests...");
-      console.log("\n");
-      openPullRequestsWithReviews
-      .forEach((pr) => {
-        if (pr.draft) {
-          console.log('\x1b[36m%s\x1b[0m (Draft)', pr.title);
-        } else if (pr.reviewStates.includes('APPROVED')) {
-          console.log('\x1b[32m%s\x1b[0m', pr.title); // green
-        } else {
-          console.log('\x1b[33m%s\x1b[0m', pr.title); // yellow
-        }
-        console.log(pr._links.html.href);
-        if (pr.reviewStates.length !== 0) {
-          console.log("Review States:", pr.reviewStates.join(', '));
-        }
+      .then(async (repos) => {
+        console.log("Found", repos.length, "repositories for team", team);
+        const result = await Promise.all(repos.map(getOpenPullRequests));
+        const openPullRequests = result.flat();
+        console.log("Found", openPullRequests.length, "open pull requests in these repos");
+        const openPullRequestsWithReviews = await Promise.all(openPullRequests.map(enhancePullRequestWithReview));
+        console.log("Getting reviews for these pull requests...");
         console.log("\n");
+        openPullRequestsWithReviews
+          .forEach((pr) => {
+            if (pr.draft) {
+              console.log('\x1b[36m%s\x1b[0m (Draft)', pr.title);
+            } else if (pr.reviewStates.includes('APPROVED')) {
+              console.log('\x1b[32m%s\x1b[0m', pr.title); // green
+            } else {
+              console.log('\x1b[33m%s\x1b[0m', pr.title); // yellow
+            }
+            console.log(pr._links.html.href);
+            if (pr.reviewStates.length !== 0) {
+              console.log("Review States:", pr.reviewStates.join(', '));
+            }
+            console.log("\n");
+          });
       });
-    });
   });
 
 program.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ config = toml.parse(file);
 program.version('1.0.0');
 program
   .action(async () => {
-    const { owner, team, token, exclude_bots: excludeBots } = config;
+    const { owner, team_slug: team, token, exclude_bots: excludeBots } = config;
     const headers = {
       'Authorization': `Bearer ${token}`,
       'Accept': 'application/vnd.github+json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": "^1.3.5",
         "commander": "^10.0.1",
-        "dotenv": "^16.0.3"
+        "toml": "^3.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -54,14 +54,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/follow-redirects": {
@@ -119,6 +111,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     }
   },
   "dependencies": {
@@ -155,11 +152,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
-    "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
-    },
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -192,6 +184,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "axios": "^1.3.5",
     "commander": "^10.0.1",
-    "dotenv": "^16.0.3"
+    "toml": "^3.0.0"
   }
 }

--- a/yanky
+++ b/yanky
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-npm start --silent
+npm --silent --prefix "$YANKY_PATH" start


### PR DESCRIPTION
Environment variables + Direnv combo is a nice way to configure applications. However it comes with a pretty big drawback: you _must_ be `cd`'d in the application's directory for your env vars to be loaded by direnv.

I would like to run `yanky` from anywhere in my CLI. However, I can't just set it in my `PATH`, because Direnv won't load my environment variables.

That's why I'm suggesting these changes: moving from env vars to a TOML config file. The config file lives alongside the executable, and is read at startup. It will always work, regardless of your current directory.

There were also some formatting issues according to my language server 🤷🏻‍♂️ 